### PR TITLE
make mqtt client id configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,4 @@ services:
             MQTT_PORT: 1883
             MQTT_USER: "johndoe"
             MQTT_PASSWORD: "sEcReT"
-            MQTT_CLIENTID: "yasdi2mqtt"
+            MQTT_CLIENT_ID: "yasdi2mqtt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,4 @@ services:
             MQTT_PORT: 1883
             MQTT_USER: "johndoe"
             MQTT_PASSWORD: "sEcReT"
+            MQTT_CLIENTID: "yasdi2mqtt"

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@ int main(int argc, char **argv)
     char *mqtt_ssl_cert = getenv("MQTT_SSL_CERT");
     char *mqtt_user = getenv("MQTT_USER");
     char *mqtt_password = getenv("MQTT_PASSWORD");
+    char *mqtt_clientid = getenv("MQTT_CLIENTID");
 
     int mqtt_qos_level = 2;
     if (getenv("MQTT_QOS_LEVEL"))
@@ -46,8 +47,9 @@ int main(int argc, char **argv)
     log_info("Configuration | MQTT_QOS_LEVEL = %d", mqtt_qos_level);
     log_info("Configuration | MQTT_USER = %s", mqtt_user);
     log_info("Configuration | MQTT_PASSWORD = %s", mqtt_password);
+    log_info("Configuration | MQTT_CLIENTID = %s", mqtt_clientid);
 
-    if (!mqtt_init(mqtt_server, mqtt_port, mqtt_ssl_cert, mqtt_user, mqtt_password, mqtt_topic_prefix, mqtt_qos_level))
+    if (!mqtt_init(mqtt_server, mqtt_port, mqtt_ssl_cert, mqtt_user, mqtt_password, mqtt_topic_prefix, mqtt_qos_level, mqtt_clientid))
     {
         log_fatal("Unable to initialize mqtt_client");
         return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -23,7 +23,14 @@ int main(int argc, char **argv)
     char *mqtt_ssl_cert = getenv("MQTT_SSL_CERT");
     char *mqtt_user = getenv("MQTT_USER");
     char *mqtt_password = getenv("MQTT_PASSWORD");
-    char *mqtt_clientid = getenv("MQTT_CLIENTID");
+
+    char *mqtt_client_id;
+    if (getenv("MQTT_CLIENT_ID"))
+    {
+      mqtt_client_id = getenv("MQTT_CLIENT_ID");
+    } else {
+      mqtt_client_id = "yasdi2mqtt";
+    }
 
     int mqtt_qos_level = 2;
     if (getenv("MQTT_QOS_LEVEL"))
@@ -47,9 +54,9 @@ int main(int argc, char **argv)
     log_info("Configuration | MQTT_QOS_LEVEL = %d", mqtt_qos_level);
     log_info("Configuration | MQTT_USER = %s", mqtt_user);
     log_info("Configuration | MQTT_PASSWORD = %s", mqtt_password);
-    log_info("Configuration | MQTT_CLIENTID = %s", mqtt_clientid);
+    log_info("Configuration | MQTT_CLIENT_ID = %s", mqtt_client_id);
 
-    if (!mqtt_init(mqtt_server, mqtt_port, mqtt_ssl_cert, mqtt_user, mqtt_password, mqtt_topic_prefix, mqtt_qos_level, mqtt_clientid))
+    if (!mqtt_init(mqtt_server, mqtt_port, mqtt_ssl_cert, mqtt_user, mqtt_password, mqtt_topic_prefix, mqtt_qos_level, mqtt_client_id))
     {
         log_fatal("Unable to initialize mqtt_client");
         return -1;

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -22,7 +22,7 @@ bool mqtt_connect();
 void mqtt_conn_lost_cb(void *context, char *cause);
 int mqtt_msg_arrived_cb(void *context, char *topicName, int topicLen, MQTTClient_message *message);
 
-bool mqtt_init(char *server, uint16_t port, char *ssl_cert, char *user, char *password, char *topic_prefix, int qos_level,char *clientid)
+bool mqtt_init(char *server, uint16_t port, char *ssl_cert, char *user, char *password, char *topic_prefix, int qos_level, char *client_id)
 {
     int status;
     topic_pfx = topic_prefix;
@@ -57,7 +57,7 @@ bool mqtt_init(char *server, uint16_t port, char *ssl_cert, char *user, char *pa
     }
     sprintf(url, "%s://%s:%u", options.ssl ? "ssl" : "tcp", server, port);
 
-    status = MQTTClient_create(&client, url, clientid, MQTTCLIENT_PERSISTENCE_NONE, NULL);
+    status = MQTTClient_create(&client, url, client_id, MQTTCLIENT_PERSISTENCE_NONE, NULL);
     if (status != MQTTCLIENT_SUCCESS)
     {
         log_fatal("Error while creating MQTTClient instance: %d", status);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -5,7 +5,6 @@
 #include <log.h>
 #include <MQTTClient.h>
 
-#define CLIENT_ID "yasdi2mqtt"
 #define MQTT_KEEP_ALIVE_INTERVAL 20
 #define MQTT_DISCONNECT_TIMEOUT 1000
 #define MQTT_RECONNECT_INTERVAL 10
@@ -23,7 +22,7 @@ bool mqtt_connect();
 void mqtt_conn_lost_cb(void *context, char *cause);
 int mqtt_msg_arrived_cb(void *context, char *topicName, int topicLen, MQTTClient_message *message);
 
-bool mqtt_init(char *server, uint16_t port, char *ssl_cert, char *user, char *password, char *topic_prefix, int qos_level)
+bool mqtt_init(char *server, uint16_t port, char *ssl_cert, char *user, char *password, char *topic_prefix, int qos_level,char *clientid)
 {
     int status;
     topic_pfx = topic_prefix;
@@ -58,7 +57,7 @@ bool mqtt_init(char *server, uint16_t port, char *ssl_cert, char *user, char *pa
     }
     sprintf(url, "%s://%s:%u", options.ssl ? "ssl" : "tcp", server, port);
 
-    status = MQTTClient_create(&client, url, CLIENT_ID, MQTTCLIENT_PERSISTENCE_NONE, NULL);
+    status = MQTTClient_create(&client, url, clientid, MQTTCLIENT_PERSISTENCE_NONE, NULL);
     if (status != MQTTCLIENT_SUCCESS)
     {
         log_fatal("Error while creating MQTTClient instance: %d", status);

--- a/src/mqtt_client.h
+++ b/src/mqtt_client.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-bool mqtt_init(char *server, uint16_t port, char *ssl_cert, char *user, char *password, char *topic_prefix, int qos_level);
+bool mqtt_init(char *server, uint16_t port, char *ssl_cert, char *user, char *password, char *topic_prefix, int qos_level, char *mqtt_client_id);
 void mqtt_destroy();
 bool mqtt_send(char *topic, char *payload);
 


### PR DESCRIPTION
clientID of mqtt is configurable; This is necessary to run multiple yasdi2mqtt containers towards the same Mqtt broker; Otherwise you receive a Mqtt client disconnect (when using same ClientID's) and container stops
