### PR TITLE
Add support for multiple drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ docker run \
    -v <project_dir>/devices:/etc/yasdi2mqtt/devices \
    -v <project_dir>/yasdi.ini:/etc/yasdi2mqtt/yasdi.ini:ro \
    -e YASDI_CONFIG="/etc/yasdi2mqtt/yasdi.ini" \
-   -e YASDI_DRIVER_ID="0" \
    -e YASDI_MAX_DEVICE_COUNT="1" \
    -e YASDI_UPDATE_INTERVAL="30" \
    -e MQTT_TOPIC_PREFIX="/solar/inverter" \
@@ -122,7 +121,6 @@ docker run \
 | Variable               | Description                                                                                                                                                                   | Example                |
 |------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|
 | YASDI_CONFIG           | Path to `yasdi.ini` file <br> *Inside container, shouldn't be changed therefore*                                                                                              | /etc/yasdi2mqtt/yasdi.ini |
-| YASDI_DRIVER_ID        | ID of driver declared in `yasdi.ini` to use                                                                                                                                   | 0                         |
 | YASDI_MAX_DEVICE_COUNT | Maximum number of devices being online at the same time                                                                                                                       | 1                         |
 | YASDI_UPDATE_INTERVAL  | Time between value update requests in seconds <br> *Value update itself takes some time, so it shouldn't be lower than 15 from my experience*                                 | 30                        |
 | MQTT_TOPIC_PREFIX      | MQTT messages will later be published to topic `$MQTT_TOPIC_PREFIX/<device_sn>`                                                                                               | solar/inverter            |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
             - "/dev/ttyUSB0:/dev/ttyUSB0"
         environment:
             YASDI_CONFIG: "/etc/yasdi2mqtt/yasdi.ini"
-            YASDI_DRIVER_ID: 0
             YASDI_MAX_DEVICE_COUNT: 1
             YASDI_UPDATE_INTERVAL: 30
             MQTT_TOPIC_PREFIX: "solar/inverter"

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,6 @@ int main(int argc, char **argv)
     log_set_level(LOG_INFO);
 
     char *yasdi_config = get_required_env("YASDI_CONFIG");
-    DWORD yasdi_driver_id = strtoul(get_required_env("YASDI_DRIVER_ID"), NULL, 10);
     DWORD yasdi_max_device_count = strtoul(get_required_env("YASDI_MAX_DEVICE_COUNT"), NULL, 10);
     unsigned int yasdi_update_interval = strtoul(get_required_env("YASDI_UPDATE_INTERVAL"), NULL, 10);
     char *mqtt_topic_prefix = get_required_env("MQTT_TOPIC_PREFIX");
@@ -42,7 +41,6 @@ int main(int argc, char **argv)
     }
 
     log_info("Configuration | YASDI_CONFIG = %s", yasdi_config);
-    log_info("Configuration | YASDI_DRIVER_ID = %u", yasdi_driver_id);
     log_info("Configuration | YASDI_MAX_DEVICE_COUNT = %u", yasdi_max_device_count);
     log_info("Configuration | YASDI_UPDATE_INTERVAL = %u", yasdi_update_interval);
     log_info("Configuration | MQTT_TOPIC_PREFIX = %s", mqtt_topic_prefix);
@@ -60,7 +58,7 @@ int main(int argc, char **argv)
         return -1;
     }
 
-    if (!yh_init(yasdi_config, yasdi_driver_id, yasdi_max_device_count, yasdi_update_interval))
+    if (!yh_init(yasdi_config, yasdi_max_device_count, yasdi_update_interval))
     {
         log_fatal("Unable to initialize yasdi_handler");
         return -1;

--- a/src/yasdi_handler.c
+++ b/src/yasdi_handler.c
@@ -57,7 +57,7 @@ bool yh_init(const char *ini_file, DWORD driver_id, DWORD device_count, unsigned
         char driver_name[256] = "N/A";
         if (!yasdiMasterGetDriverName(drivers[i], driver_name, sizeof(driver_name)))
         {
-            log_error("Unable to get driver name for ID: %u", drivers[i]);
+            log_warn("Unable to get driver name for ID: %u", drivers[i]);
         }
 
         if (!yasdiMasterSetDriverOnline(drivers[i]))

--- a/src/yasdi_handler.c
+++ b/src/yasdi_handler.c
@@ -31,7 +31,7 @@ void device_detection_cb(TYASDIDetectionSub event, DWORD device);
  * @param device_update_interval seconds to wait between device value updates
  * @return true if initialization succeeded
  */
-bool yh_init(const char *ini_file, DWORD driver_id, DWORD device_count, unsigned int device_update_interval)
+bool yh_init(const char *ini_file, DWORD device_count, unsigned int device_update_interval)
 {
     int status;
     max_device_count = device_count;

--- a/src/yasdi_handler.c
+++ b/src/yasdi_handler.c
@@ -26,7 +26,6 @@ void device_detection_cb(TYASDIDetectionSub event, DWORD device);
 /**
  * Initializes yasdiMaster, enables the driver and prepares for device detection. Must be called first.
  * @param ini_file               relative location of yasdi.ini file
- * @param driver_id              id of the yasdi.ini driver to use (counts from 0)
  * @param device_countmaximum    amount of devices that might be connected at the same time
  * @param device_update_interval seconds to wait between device value updates
  * @return true if initialization succeeded

--- a/src/yasdi_handler.h
+++ b/src/yasdi_handler.h
@@ -16,7 +16,7 @@ struct device_value_t
 
 extern void (*yh_new_values_cb)(struct device_value_t *);
 
-bool yh_init(const char *ini_file, DWORD driver_id, DWORD device_count, unsigned int device_update_interval);
+bool yh_init(const char *ini_file, DWORD device_count, unsigned int device_update_interval);
 void yh_destroy();
 void yh_loop();
 


### PR DESCRIPTION
In some cases, e.g. when using RS232 interfaces, you will have multiple interfaces in your yasdi.ini like this:

```
[COM1]
Device=/dev/ttyUSB0
Media=RS232
Baudrate=1200
Protocol=SMANet

[COM2]
Device=/dev/ttyUSB1
Media=RS232
Baudrate=1200
Protocol=SMANet
```

yasdi represents these as individual drivers (with the names COM1 and COM2 respectively). The current implementation only allows one of these to be used. This PR brings all defined drivers online instead.